### PR TITLE
ci: build workspace packages before release binaries

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build packages
+        run: bun run build
+
       - name: Build binaries
         run: bun scripts/build-release.ts
 


### PR DESCRIPTION
## Summary
- Add `bun run build` step before building release binaries in CI workflow
- Fixes the build-binaries job failing with "Could not resolve: @pleaseai/mcp-core"

## Root Cause
The `build-binaries` job was running `bun scripts/build-release.ts` without first building the workspace packages. `Bun.build()` with compile mode needs the workspace packages to be compiled.

## Test plan
- [ ] Verify CI workflow passes on this PR