### PR TITLE
feat(oauth): add port retry logic for OAuth callback server

### DIFF
--- a/packages/mcp/src/utils/oauth/oauth-manager.ts
+++ b/packages/mcp/src/utils/oauth/oauth-manager.ts
@@ -99,6 +99,7 @@ export class OAuthManager {
   private isPortAvailable(port: number): Promise<boolean> {
     return new Promise((resolve) => {
       const server = createServer()
+      server.unref() // Prevent server from keeping the process alive
       server.once('error', (err: NodeJS.ErrnoException) => {
         if (err.code !== 'EADDRINUSE') {
           this.logger.debug(`Port ${port} check failed: ${err.code} - ${err.message}`)

--- a/packages/mcp/tests/oauth-port-retry.test.ts
+++ b/packages/mcp/tests/oauth-port-retry.test.ts
@@ -204,12 +204,8 @@ describe('oauth-port-retry', () => {
       expect(port).toBe(testPort)
     })
 
-    test('should return actualCallbackPort when set', async () => {
+    test('should return actualCallbackPort when set', () => {
       const testPort = getTestPortBase()
-
-      // Occupy the default port to force fallback
-      await occupyPort(testPort)
-
       const manager = new OAuthManager(
         {
           serverName: 'test-server',
@@ -219,15 +215,12 @@ describe('oauth-port-retry', () => {
         },
         { debug: false },
       )
-
-      // Simulate what authorize() does
-      const findPort = (manager as any).findAvailablePort.bind(manager);
-      (manager as any).actualCallbackPort = await findPort()
-
+      // Directly set the property for a true unit test
+      const expectedPort = testPort + 5;
+      (manager as any).actualCallbackPort = expectedPort
       const getPort = (manager as any).getCallbackPort.bind(manager)
       const port = getPort()
-
-      expect(port).toBe(testPort + 1)
+      expect(port).toBe(expectedPort)
     })
   })
 })


### PR DESCRIPTION
## Summary

- Add port retry logic to OAuth callback server when default port (3334) is in use
- Implement hybrid approach: port-first discovery + backup retry for race conditions
- Provide clear error messages when all ports exhausted

Closes #15

## Architecture Approach

**Hybrid (Port-First + Backup Retry)**:
1. **Port-first discovery**: Find available port BEFORE client registration
2. **Backup retry**: Handle rare race conditions in `waitForCallback()`

### New Components
- `MAX_PORT_ATTEMPTS = 10` constant
- `actualCallbackPort` class property
- `isPortAvailable()` helper method with error logging
- `findAvailablePort()` method with retry loop
- `getCallbackPort()` accessor method

### Modified Methods
- `authorize()` - calls `findAvailablePort()` before registration
- `registerClient()` - uses actual port for redirect URI
- `performAuthorizationFlow()` - uses actual port for redirect URI  
- `waitForCallback()` - uses actual port, has backup EADDRINUSE handling

## Changes

| File | Lines | Description |
|------|-------|-------------|
| `packages/mcp/src/utils/oauth/oauth-manager.ts` | +70 | Port retry implementation |
| `packages/mcp/tests/oauth-port-retry.test.ts` | +233 | Unit tests for port retry |

## Test plan

- [x] Unit test: `isPortAvailable()` returns true for free port
- [x] Unit test: `isPortAvailable()` returns false for occupied port
- [x] Unit test: `findAvailablePort()` returns first available port
- [x] Unit test: `findAvailablePort()` skips occupied ports with warning log
- [x] Unit test: `findAvailablePort()` throws after MAX_PORT_ATTEMPTS
- [x] Unit test: `getCallbackPort()` returns configured vs actual port

All 38 tests pass.